### PR TITLE
fix: fix issue 73 Product Showcase Component overlapping vaultDrawer …

### DIFF
--- a/src/components/ui/drawer/VaulDrawer.tsx
+++ b/src/components/ui/drawer/VaulDrawer.tsx
@@ -18,7 +18,7 @@ export default function VaulDrawer() {
 
       <Drawer.Portal>
         <Drawer.Overlay className="fixed inset-0 bg-black/60" />
-        <Drawer.Content className="bg-[var(--background-color)] flex flex-col rounded-t-3xl border-t border-[var(--primary-color-1)] h-[80%] lg:h-80 fixed bottom-0 left-0 right-0 outline-none z-50 p-5">
+        <Drawer.Content className="bg-[var(--background-color)] flex flex-col rounded-t-3xl border-t border-[var(--primary-color-1)] h-[80%] lg:h-80 fixed bottom-0 left-0 right-0 outline-none z-[1000] p-5">
           <div className="overflow-y-auto">
             <div className="w-24 h-[1px] mx-auto bg-[var(--primary-color-2)]" />
             <div className="text-sm px-2 space-y-1 py-6">


### PR DESCRIPTION
This should fix Issue 73, But I was not able to run this project properly to test this out, as it crashes my termal and vs code, I tried deleting .next and node_modules and reintall again with yarn but still the same issue presist

<img width="2438" height="1318" alt="image" src="https://github.com/user-attachments/assets/02066085-de5f-46ce-8ef3-7ae0057d9b7a" />
<img width="1008" height="1089" alt="image" src="https://github.com/user-attachments/assets/97466093-b095-4fa0-98b6-08cba8dc26c8" />
